### PR TITLE
fix：jsdelivr mirror

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,11 +37,11 @@
     </script>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/gh/lipis/flag-icons@7.0.0/css/flag-icons.min.css"
+      href="https://fastly.jsdelivr.net/gh/lipis/flag-icons@7.0.0/css/flag-icons.min.css"
     />
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/font-logos@1/assets/font-logos.css"
+      href="https://fastly.jsdelivr.net/npm/font-logos@1/assets/font-logos.css"
     />
   </head>
   <body>


### PR DESCRIPTION
将引用的jsdelivr资源更改为fastly的地址，解决中国大陆访问不畅的问题