### PR TITLE
fix: add 404 redirect

### DIFF
--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -9,9 +9,9 @@ export default function NotFound() {
 
   useEffect(() => {
     if (window.location.pathname !== "/404") {
-      window.location.href = "/404";
+      window.location.href = "/404"
     }
-  }, []);
+  }, [])
 
   return (
     <div className="flex  flex-col items-center justify-center">

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,10 +1,17 @@
 import { Button } from "@/components/ui/button"
+import { useEffect } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 
 export default function NotFound() {
   const navigate = useNavigate()
   const { t } = useTranslation()
+
+  useEffect(() => {
+    if (window.location.pathname !== "/404") {
+      window.location.href = "/404";
+    }
+  }, []);
 
   return (
     <div className="flex  flex-col items-center justify-center">


### PR DESCRIPTION
Redirect all not-found URL accesses to /404 path.
This is useful for the backend to return a 404 http status code on a specific path