### PR TITLE
feat: add boot time display in ServerDetailOverview and localization …

### DIFF
--- a/src/components/ServerDetailOverview.tsx
+++ b/src/components/ServerDetailOverview.tsx
@@ -74,6 +74,7 @@ export default function ServerDetailOverview({ server_id }: { server_id: string 
     net_out_transfer,
     net_in_transfer,
     last_active_time_string,
+    boot_time_string,
   } = formatNezhaInfo(nezhaWsData.now, server)
 
   const customBackgroundImage = (window.CustomBackgroundImage as string) !== "" ? window.CustomBackgroundImage : undefined
@@ -285,6 +286,14 @@ export default function ServerDetailOverview({ server_id }: { server_id: string 
       </section>
 
       <section className="flex flex-wrap gap-2 mt-1">
+      <Card className="rounded-[10px] bg-transparent border-none shadow-none">
+          <CardContent className="px-1.5 py-1">
+            <section className="flex flex-col items-start gap-0.5">
+              <p className="text-xs text-muted-foreground">{t("serverDetail.bootTime")}</p>
+              <div className="text-xs">{boot_time_string ? boot_time_string : "N/A"}</div>
+            </section>
+          </CardContent>
+        </Card>
         <Card className="rounded-[10px] bg-transparent border-none shadow-none">
           <CardContent className="px-1.5 py-1">
             <section className="flex flex-col items-start gap-0.5">

--- a/src/components/ServerDetailOverview.tsx
+++ b/src/components/ServerDetailOverview.tsx
@@ -286,7 +286,7 @@ export default function ServerDetailOverview({ server_id }: { server_id: string 
       </section>
 
       <section className="flex flex-wrap gap-2 mt-1">
-      <Card className="rounded-[10px] bg-transparent border-none shadow-none">
+        <Card className="rounded-[10px] bg-transparent border-none shadow-none">
           <CardContent className="px-1.5 py-1">
             <section className="flex flex-col items-start gap-0.5">
               <p className="text-xs text-muted-foreground">{t("serverDetail.bootTime")}</p>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -35,9 +35,7 @@ export function formatNezhaInfo(now: number, serverInfo: NezhaServer) {
     swap_total: serverInfo.host.swap_total || 0,
     disk_total: serverInfo.host.disk_total || 0,
     boot_time: serverInfo.host.boot_time || 0,
-    boot_time_string: serverInfo.host.boot_time
-      ? dayjs(serverInfo.host.boot_time * 1000).format("YYYY-MM-DD HH:mm:ss")
-      : "",
+    boot_time_string: serverInfo.host.boot_time ? dayjs(serverInfo.host.boot_time * 1000).format("YYYY-MM-DD HH:mm:ss") : "",
     platform_version: serverInfo.host.platform_version || "",
     cpu_info: serverInfo.host.cpu || [],
     gpu_info: serverInfo.host.gpu || [],

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -35,6 +35,9 @@ export function formatNezhaInfo(now: number, serverInfo: NezhaServer) {
     swap_total: serverInfo.host.swap_total || 0,
     disk_total: serverInfo.host.disk_total || 0,
     boot_time: serverInfo.host.boot_time || 0,
+    boot_time_string: serverInfo.host.boot_time
+      ? dayjs(serverInfo.host.boot_time * 1000).format("YYYY-MM-DD HH:mm:ss")
+      : "",
     platform_version: serverInfo.host.platform_version || "",
     cpu_info: serverInfo.host.cpu || [],
     gpu_info: serverInfo.host.gpu || [],

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -67,7 +67,8 @@
     "upload": "Upload",
     "download": "Download",
     "lastActive": "Last active time",
-    "temperature": "Temperature"
+    "temperature": "Temperature",
+    "bootTime": "Boot time"
   },
   "serverDetailChart": {
     "process": "Process",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -67,7 +67,8 @@
     "upload": "上传",
     "download": "下载",
     "lastActive": "最后上报时间",
-    "temperature": "温度"
+    "temperature": "温度",
+    "bootTime": "启动时间"
   },
   "serverDetailChart": {
     "process": "进程数",

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -67,7 +67,8 @@
     "upload": "上傳",
     "download": "下載",
     "lastActive": "最後上報時間",
-    "temperature": "溫度"
+    "temperature": "溫度",
+    "bootTime": "啟動時間"
   },
   "serverDetailChart": {
     "process": "進程數",


### PR DESCRIPTION
…support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new display element in the server details view that shows the server’s boot time in a human-readable format, with a fallback ("N/A") if the data isn’t available.

- **Documentation**
  - Enhanced language support by updating translations to include boot time labels in English, Simplified Chinese, and Traditional Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->